### PR TITLE
Fix single channel png e2p

### DIFF
--- a/convert360
+++ b/convert360
@@ -52,4 +52,4 @@ else:
     raise NotImplementedError('Unknown convertion')
 
 # Output image
-Image.fromarray(out.astype(np.uint8)).save(args.o)
+Image.fromarray(out.astype(np.uint8).squeeze()).save(args.o)


### PR DESCRIPTION
pillow does not accept h x w x 1 numpy arrays, added squeeze to make it h x w for single channel image.