### PR TITLE
Fix np.bool NumPy 1.20 deprecation error.

### DIFF
--- a/py360convert/utils.py
+++ b/py360convert/utils.py
@@ -51,7 +51,7 @@ def equirect_facetype(h, w):
     tp = np.roll(np.arange(4).repeat(w // 4)[None, :].repeat(h, 0), 3 * w // 8, 1)
 
     # Prepare ceil mask
-    mask = np.zeros((h, w // 4), np.bool)
+    mask = np.zeros((h, w // 4), np.bool_)
     idx = np.linspace(-np.pi, np.pi, w // 4) / 4
     idx = h // 2 - np.round(np.arctan(np.cos(idx)) * h / np.pi).astype(int)
     for i, j in enumerate(idx):


### PR DESCRIPTION
In `utils.py`, line 54, we reference `np.bool`, which causes this error:

```
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'bool_'?
```

To fix it, I have simply renamed `np.bool` to `np.bool_`.

