### PR TITLE
Speed Optimizations.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,7 +93,17 @@ jobs:
           source ${{ env.ACTIVATE_PYTHON_VENV }}
           pre-commit run --show-diff-on-failure --color=always --all-files
 
-      - name: Run tests
+      - name: Run tests (standard install)
+        run: |
+          source ${{ env.ACTIVATE_PYTHON_VENV }}
+          python -m pytest
+
+      - name: Install opencv
+        run: |
+          source ${{ env.ACTIVATE_PYTHON_VENV }}
+          pip install opencv-python
+
+      - name: Run tests (with opencv)
         run: |
           source ${{ env.ACTIVATE_PYTHON_VENV }}
           python -m pytest

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # py360convert
 
 Features of this project:
-- Conversion between cubemap and equirectangular  
+- Conversion between cubemap and equirectangular:
     ![](assets/teaser_convertion.png)
-- Equirectangular to planar  
+- Conversion between Equirectangular and planar:
     ![](assets/teaser_2planar.png)
-- Pure python implementation and depend only on [numpy](http://www.numpy.org/) and [scipy](https://www.scipy.org/)
-- Vectorization implementation (in most of the place)
-    - `c2e` takes 300ms and `e2c` takes 160ms on 1.6 GHz Intel Core i5 CPU
+- Pure python implementation and depend only on [numpy](http://www.numpy.org/) and [scipy](https://www.scipy.org/).
+- Vectorization implementation:
+    - If opencv is installed, py360convert will automatically use it to accelerate computations (several times speedup).
 
 ## Install
 ```

--- a/py360convert/c2e.py
+++ b/py360convert/c2e.py
@@ -126,10 +126,7 @@ def c2e(
         raise ValueError("w must be a multiple of 8.")
     face_w = cubemap.shape[0]
 
-    uv = equirect_uvgrid(h, w)
-    u, v = np.split(uv, 2, axis=-1)
-    u = u[..., 0]
-    v = v[..., 0]
+    u, v = equirect_uvgrid(h, w)
     cube_faces = np.stack(np.split(cubemap, 6, 1), 0)
 
     # Get face id to each pixel: 0F 1R 2B 3L 4U 5D

--- a/py360convert/c2e.py
+++ b/py360convert/c2e.py
@@ -132,8 +132,8 @@ def c2e(
     # Get face id to each pixel: 0F 1R 2B 3L 4U 5D
     tp = equirect_facetype(h, w)
 
-    coor_x = np.empty((h, w))
-    coor_y = np.empty((h, w))
+    coor_x = np.empty((h, w), dtype=np.float32)
+    coor_y = np.empty((h, w), dtype=np.float32)
     face_w2 = face_w / 2
 
     # Middle band (front/right/back/left)

--- a/py360convert/c2e.py
+++ b/py360convert/c2e.py
@@ -7,6 +7,7 @@ from .utils import (
     CubeFormat,
     DType,
     Face,
+    ImageSampler2d,
     InterpolationMode,
     cube_dice2list,
     cube_dict2list,
@@ -14,7 +15,6 @@ from .utils import (
     equirect_facetype,
     equirect_uvgrid,
     mode_to_order,
-    sample_cubefaces,
 )
 
 
@@ -163,7 +163,8 @@ def c2e(
     coor_y.clip(0, face_w, out=coor_y)
 
     equirec = np.empty((h, w, cube_faces.shape[3]), dtype=cube_faces[0].dtype)
+    sampler = ImageSampler2d(tp, coor_x, coor_y, order, face_w, face_w)
     for i in range(cube_faces.shape[3]):
-        equirec[..., i] = sample_cubefaces(cube_faces[..., i], tp, coor_y, coor_x, order=order)
+        equirec[..., i] = sampler(cube_faces[..., i])
 
     return equirec[..., 0] if squeeze else equirec

--- a/py360convert/c2e.py
+++ b/py360convert/c2e.py
@@ -4,10 +4,10 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .utils import (
+    CubeFaceSampler,
     CubeFormat,
     DType,
     Face,
-    ImageSampler2d,
     InterpolationMode,
     cube_dice2list,
     cube_dict2list,
@@ -163,7 +163,7 @@ def c2e(
     coor_y.clip(0, face_w, out=coor_y)
 
     equirec = np.empty((h, w, cube_faces.shape[3]), dtype=cube_faces[0].dtype)
-    sampler = ImageSampler2d(tp, coor_x, coor_y, order, face_w, face_w)
+    sampler = CubeFaceSampler(tp, coor_x, coor_y, order, face_w, face_w)
     for i in range(cube_faces.shape[3]):
         equirec[..., i] = sampler(cube_faces[..., i])
 

--- a/py360convert/c2e.py
+++ b/py360convert/c2e.py
@@ -156,7 +156,7 @@ def c2e(
     coor_x_norm = (np.clip(coor_x, -0.5, 0.5) + 0.5) * face_w
     coor_y_norm = (np.clip(coor_y, -0.5, 0.5) + 0.5) * face_w
 
-    equirec = np.empty((h, w, cube_faces.shape[3]))
+    equirec = np.empty((h, w, cube_faces.shape[3]), dtype=cube_faces[0].dtype)
     for i in range(cube_faces.shape[3]):
         equirec[..., i] = sample_cubefaces(cube_faces[..., i], tp, coor_y_norm, coor_x_norm, order=order)
 

--- a/py360convert/e2c.py
+++ b/py360convert/e2c.py
@@ -6,12 +6,12 @@ from numpy.typing import NDArray
 from .utils import (
     CubeFormat,
     DType,
+    EquirecSampler,
     InterpolationMode,
     cube_h2dice,
     cube_h2dict,
     cube_h2list,
     mode_to_order,
-    sample_equirec,
     uv2coor,
     xyz2uv,
     xyzcube,
@@ -82,10 +82,11 @@ def e2c(
 
     xyz = xyzcube(face_w)
     uv = xyz2uv(xyz)
-    coor_xy = uv2coor(uv, h, w)
+    coor_x, coor_y = uv2coor(uv, h, w)
 
+    sampler = EquirecSampler(coor_x, coor_y, order)
     cubemap = np.stack(
-        [sample_equirec(e_img[..., i], coor_xy, order=order) for i in range(e_img.shape[2])],
+        [sampler(e_img[..., i]) for i in range(e_img.shape[2])],
         axis=-1,
         dtype=e_img.dtype,
     )

--- a/py360convert/e2c.py
+++ b/py360convert/e2c.py
@@ -81,8 +81,8 @@ def e2c(
     order = mode_to_order(mode)
 
     xyz = xyzcube(face_w)
-    uv = xyz2uv(xyz)
-    coor_x, coor_y = uv2coor(uv, h, w)
+    u, v = xyz2uv(xyz)
+    coor_x, coor_y = uv2coor(u, v, h, w)
 
     sampler = EquirecSampler(coor_x, coor_y, order)
     cubemap = np.stack(

--- a/py360convert/e2p.py
+++ b/py360convert/e2p.py
@@ -6,9 +6,9 @@ from numpy.typing import NDArray
 
 from .utils import (
     DType,
+    EquirecSampler,
     InterpolationMode,
     mode_to_order,
-    sample_equirec,
     uv2coor,
     xyz2uv,
     xyzpers,
@@ -71,8 +71,9 @@ def e2p(
     v = v_deg * np.pi / 180
     xyz = xyzpers(h_fov, v_fov, u, v, out_hw, in_rot)
     uv = xyz2uv(xyz)
-    coor_xy = uv2coor(uv, h, w)
+    coor_x, coor_y = uv2coor(uv, h, w)
 
-    pers_img = np.stack([sample_equirec(e_img[..., i], coor_xy, order=order) for i in range(e_img.shape[2])], axis=-1)
+    sampler = EquirecSampler(coor_x, coor_y, order)
+    pers_img = np.stack([sampler(e_img[..., i]) for i in range(e_img.shape[2])], axis=-1)
 
     return pers_img[..., 0] if squeeze else pers_img

--- a/py360convert/e2p.py
+++ b/py360convert/e2p.py
@@ -70,8 +70,8 @@ def e2p(
     u = -u_deg * np.pi / 180
     v = v_deg * np.pi / 180
     xyz = xyzpers(h_fov, v_fov, u, v, out_hw, in_rot)
-    uv = xyz2uv(xyz)
-    coor_x, coor_y = uv2coor(uv, h, w)
+    u, v = xyz2uv(xyz)
+    coor_x, coor_y = uv2coor(u, v, h, w)
 
     sampler = EquirecSampler(coor_x, coor_y, order)
     pers_img = np.stack([sampler(e_img[..., i]) for i in range(e_img.shape[2])], axis=-1)

--- a/py360convert/utils.py
+++ b/py360convert/utils.py
@@ -243,7 +243,7 @@ def xyzpers(h_fov: float, v_fov: float, u: float, v: float, out_hw: tuple[int, i
     return out.dot(Rx).dot(Ry).dot(Ri)
 
 
-def xyz2uv(xyz: NDArray[DType]) -> NDArray[DType]:
+def xyz2uv(xyz: NDArray[DType]) -> tuple[NDArray[DType], NDArray[DType]]:
     """Transform cartesian (x,y,z) to spherical(r, u, v), and only outputs (u, v).
 
     Parameters
@@ -268,10 +268,9 @@ def xyz2uv(xyz: NDArray[DType]) -> NDArray[DType]:
     """
     x, y, z = np.split(xyz, 3, axis=-1)
     u = np.arctan2(x, z)
-    c = np.sqrt(np.square(x) + np.square(z))
+    c = np.hypot(x, z)
     v = np.arctan2(y, c)
-    out = np.concatenate([u, v], axis=-1, dtype=xyz.dtype)
-    return out
+    return u, v
 
 
 def uv2unitxyz(uv: NDArray[DType]) -> NDArray[DType]:
@@ -283,7 +282,7 @@ def uv2unitxyz(uv: NDArray[DType]) -> NDArray[DType]:
     return np.concatenate([x, y, z], axis=-1, dtype=uv.dtype)
 
 
-def uv2coor(uv: NDArray[DType], h: int, w: int) -> tuple[NDArray[DType], NDArray[DType]]:
+def uv2coor(u: NDArray[DType], v: NDArray[DType], h: int, w: int) -> tuple[NDArray[DType], NDArray[DType]]:
     """Transform spherical(r, u, v) into equirectangular(x, y).
 
     Assume that u has range 2pi and v has range pi.
@@ -311,7 +310,6 @@ def uv2coor(uv: NDArray[DType], h: int, w: int) -> tuple[NDArray[DType], NDArray
         * coor_x is in [-0.5, w-0.5]
         * coor_y is in [-0.5, h-0.5]
     """
-    u, v = np.split(uv, 2, axis=-1)
     coor_x = (u / (2 * np.pi) + 0.5) * w - 0.5  # pyright: ignore[reportOperatorIssue]
     coor_y = (-v / np.pi + 0.5) * h - 0.5  # pyright: ignore[reportOperatorIssue]
     return coor_x, coor_y

--- a/py360convert/utils.py
+++ b/py360convert/utils.py
@@ -340,7 +340,7 @@ def sample_cubefaces(
     BELOW = (-1, slice(None))
     LEFT = (slice(None), 0)
     RIGHT = (slice(None), -1)
-    padded = np.pad(cube_faces, ((0, 0), (1, 1), (1, 1)), mode="constant")
+    padded = np.pad(cube_faces, ((0, 0), (1, 1), (1, 1)), mode="empty")
 
     # Pad above/below
     padded[Face.FRONT][ABOVE] = padded[Face.UP, -2, :]

--- a/py360convert/utils.py
+++ b/py360convert/utils.py
@@ -8,7 +8,7 @@ from scipy.ndimage import map_coordinates
 from scipy.spatial.transform import Rotation
 
 try:
-    import cv2
+    import cv2  # pyright: ignore[reportMissingImports]
 except ImportError:
     cv2 = None
 

--- a/py360convert/utils.py
+++ b/py360convert/utils.py
@@ -266,7 +266,9 @@ def xyz2uv(xyz: NDArray[DType]) -> tuple[NDArray[DType], NDArray[DType]]:
         * v is in [-pi/2, pi/2]
         * any point i of output array is in [-pi, pi] x [-pi/2, pi/2].
     """
-    x, y, z = np.split(xyz, 3, axis=-1)
+    x = xyz[..., 0:1]  # Keep dimensions but avoid copy
+    y = xyz[..., 1:2]
+    z = xyz[..., 2:3]
     u = np.arctan2(x, z)
     c = np.hypot(x, z)
     v = np.arctan2(y, c)

--- a/py360convert/utils.py
+++ b/py360convert/utils.py
@@ -91,48 +91,59 @@ def xyzcube(face_w: int) -> NDArray[np.float32]:
 
     Parameters
     ----------
-        face_w: int
-            Specify the length of each face of the cubemap.
+    face_w: int
+        Specify the length of each face of the cubemap.
 
     Returns
     -------
-        out: ndarray
-            An array object with dimension (face_w, face_w * 6, 3)
-            which store the each face of numalized cube coordinates.
-            The cube is centered at the origin so that each face k
-            in out has range [-0.5, 0.5] x [-0.5, 0.5].
-
+    out: ndarray
+        An array object with dimension (face_w, face_w * 6, 3)
+        which store the each face of numalized cube coordinates.
+        The cube is centered at the origin so that each face k
+        in out has range [-0.5, 0.5] x [-0.5, 0.5].
     """
-    out = np.zeros((face_w, face_w * 6, 3), np.float32)
+    out = np.empty((face_w, face_w * 6, 3), np.float32)
+
+    # Create coordinates once and reuse
     rng = np.linspace(-0.5, 0.5, num=face_w, dtype=np.float32)
-    grid = np.stack(np.meshgrid(rng, -rng), -1)
+    x, y = np.meshgrid(rng, -rng)
+
+    # Pre-compute flips
+    x_flip = np.flip(x, 1)
+    y_flip = np.flip(y, 0)
 
     def face_slice(index):
         return slice_chunk(index, face_w)
 
     # Front face (z = 0.5)
-    out[:, face_slice(Face.FRONT), [Dim.X, Dim.Y]] = grid
+    out[:, face_slice(Face.FRONT), Dim.X] = x
+    out[:, face_slice(Face.FRONT), Dim.Y] = y
     out[:, face_slice(Face.FRONT), Dim.Z] = 0.5
 
     # Right face (x = 0.5)
-    out[:, face_slice(Face.RIGHT), [Dim.Z, Dim.Y]] = np.flip(grid, axis=1)
     out[:, face_slice(Face.RIGHT), Dim.X] = 0.5
+    out[:, face_slice(Face.RIGHT), Dim.Y] = y
+    out[:, face_slice(Face.RIGHT), Dim.Z] = x_flip
 
     # Back face (z = -0.5)
-    out[:, face_slice(Face.BACK), [Dim.X, Dim.Y]] = np.flip(grid, axis=1)
+    out[:, face_slice(Face.BACK), Dim.X] = x_flip
+    out[:, face_slice(Face.BACK), Dim.Y] = y
     out[:, face_slice(Face.BACK), Dim.Z] = -0.5
 
     # Left face (x = -0.5)
-    out[:, face_slice(Face.LEFT), [Dim.Z, Dim.Y]] = grid
     out[:, face_slice(Face.LEFT), Dim.X] = -0.5
+    out[:, face_slice(Face.LEFT), Dim.Y] = y
+    out[:, face_slice(Face.LEFT), Dim.Z] = x
 
     # Up face (y = 0.5)
-    out[:, face_slice(Face.UP), [Dim.X, Dim.Z]] = np.flip(grid, axis=0)
+    out[:, face_slice(Face.UP), Dim.X] = x
     out[:, face_slice(Face.UP), Dim.Y] = 0.5
+    out[:, face_slice(Face.UP), Dim.Z] = y_flip
 
     # Down face (y = -0.5)
-    out[:, face_slice(Face.DOWN), [Dim.X, Dim.Z]] = grid
+    out[:, face_slice(Face.DOWN), Dim.X] = x
     out[:, face_slice(Face.DOWN), Dim.Y] = -0.5
+    out[:, face_slice(Face.DOWN), Dim.Z] = y
 
     return out
 

--- a/py360convert/utils.py
+++ b/py360convert/utils.py
@@ -132,11 +132,10 @@ def xyzcube(face_w: int) -> NDArray[np.float32]:
     return out
 
 
-def equirect_uvgrid(h: int, w: int) -> NDArray[np.float32]:
+def equirect_uvgrid(h: int, w: int) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
     u = np.linspace(-np.pi, np.pi, num=w, dtype=np.float32)
-    v = np.linspace(np.pi, -np.pi, num=h, dtype=np.float32) / 2
-
-    return np.stack(np.meshgrid(u, v), axis=-1)
+    v = np.linspace(np.pi / 2, -np.pi / 2, num=h, dtype=np.float32)
+    return np.meshgrid(u, v)  # pyright: ignore[reportReturnType]
 
 
 def equirect_facetype(h: int, w: int) -> NDArray[np.int32]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ ignore = [
     "E501",
     "F401",
     "N806",
+    "PGH003",  # Use specific rule codes when ignoring type issues
     "TRY003",  # Avoid specifying messages outside exception class; overly strict, especially for ValueError
 ]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,7 @@ def diff(x, y):
 
 def test_c2e_dice(equirec_image, dice_image):
     equirec_actual = py360convert.c2e(dice_image, 512, 1024)
+    assert equirec_actual.dtype == dice_image.dtype
     equirec_diff = diff(equirec_image, equirec_actual)
     assert equirec_diff.mean() < AVG_DIFF_THRESH
 


### PR DESCRIPTION
Contains many macro/micro optimizations. Most notably:
1. If opencv is installed, will use it for `remap` instead of using scipy's `map_coordinates`. The opencv implementation is several times faster. If opencv is used, coordinate calculations are also cached, further speeding it up.
2. Replace a lot of `np.zeros` with `np.empty`.
3. Remove a lot of unnecessary `np.concatenate`/`np.split`.
4. Pre-allocate buffers instead of performing several concatenations/stacking.
5. Faster array indexing/ordering.
6. Reduce calculations to just possible regions of the image they could apply to.

# Bug Fixes
* `c2e` wasn't returning the proper dtype.

# To be fixed bugs
@ProGamerGov I think there's an off-by-one bug in the y-coordinates when sampling equirectangular images (inside the newly created `EquirecSampler`, previously inside `equirec_sample`). To be fixed in a follow up PR. If you want to update your repo with similar optimizations, all the changes in this PR are purely for speed (I went through all functions with line-profiler).