### PR TITLE
fix: Use f-strings in ValueError messages

### DIFF
--- a/py360convert/c2e.py
+++ b/py360convert/c2e.py
@@ -116,7 +116,7 @@ def c2e(
             squeeze = False
         cube_faces = cube_dice2list(cubemap)
     else:
-        raise ValueError('Unknown cube_format "{cube_format}".')
+        raise ValueError(f'Unknown cube_format "{cube_format}".')
 
     cube_faces = np.stack(cube_faces)
 

--- a/py360convert/utils.py
+++ b/py360convert/utils.py
@@ -548,9 +548,9 @@ class CubeFaceSampler:
         """
         h, w = cube_faces.shape[-2:]
         if h != self._h:
-            raise ValueError("Input height {h} doesn't match expected height {self._h}.")
+            raise ValueError(f"Input height {h} doesn't match expected height {self._h}.")
         if w != self._w:
-            raise ValueError("Input width {w} doesn't match expected height {self._w}.")
+            raise ValueError(f"Input width {w} doesn't match expected height {self._w}.")
 
         if cube_faces.dtype == np.float16:
             source_dtype = np.float16


### PR DESCRIPTION
Changed ValueError messages to use f-strings so that variable values (cube_format, h, w, self._h, self._w) are shown in the error output instead of variable names.